### PR TITLE
Issue25

### DIFF
--- a/src/main/scala/org/zalando/jsonapi/json/playjson/PlayJsonJsonapiFormat.scala
+++ b/src/main/scala/org/zalando/jsonapi/json/playjson/PlayJsonJsonapiFormat.scala
@@ -220,16 +220,15 @@ trait PlayJsonJsonapiFormat {
     }
 
     override def reads(json: JsValue): JsResult[Links] = json match {
-      case JsObject(o) ⇒ JsSuccess(o.map { keyValue ⇒
-        keyValue match {
-          case (FieldNames.`about`, JsString(u))   ⇒ Links.About(u)
-          case (FieldNames.`first`, JsString(u))   ⇒ Links.First(u)
-          case (FieldNames.`last`, JsString(u))    ⇒ Links.Last(u)
-          case (FieldNames.`next`, JsString(u))    ⇒ Links.Next(u)
-          case (FieldNames.`prev`, JsString(u))    ⇒ Links.Prev(u)
-          case (FieldNames.`related`, JsString(u)) ⇒ Links.Related(u)
-          case (FieldNames.`self`, JsString(u))    ⇒ Links.Self(u)
-        }
+      case JsObject(o) ⇒ JsSuccess(o.flatMap {
+        case (FieldNames.`about`, JsString(u))   ⇒ Option(Links.About(u))
+        case (FieldNames.`first`, JsString(u))   ⇒ Option(Links.First(u))
+        case (FieldNames.`last`, JsString(u))    ⇒ Option(Links.Last(u))
+        case (FieldNames.`next`, JsString(u))    ⇒ Option(Links.Next(u))
+        case (FieldNames.`prev`, JsString(u))    ⇒ Option(Links.Prev(u))
+        case (FieldNames.`related`, JsString(u)) ⇒ Option(Links.Related(u))
+        case (FieldNames.`self`, JsString(u))    ⇒ Option(Links.Self(u))
+        case _                                   ⇒ None
       }.toVector)
       case _ ⇒ JsError("error.expected.links")
     }

--- a/src/main/scala/org/zalando/jsonapi/json/playjson/PlayJsonJsonapiSupport.scala
+++ b/src/main/scala/org/zalando/jsonapi/json/playjson/PlayJsonJsonapiSupport.scala
@@ -2,12 +2,46 @@ package org.zalando.jsonapi.json
 package playjson
 
 import org.zalando.jsonapi.model.RootObject
-import play.api.libs.json.{ Json, JsValue }
-import spray.httpx.PlayJsonSupport
+import play.api.libs.json._
+import spray.http.MediaTypes._
+import spray.http._
 import spray.httpx.marshalling.Marshaller
-import spray.httpx.unmarshalling.Unmarshaller
+import spray.httpx.unmarshalling._
 
-trait PlayJsonJsonapiSupport extends PlayJsonJsonapiFormat with PlayJsonSupport {
+import scala.util.control.NonFatal
+
+trait PlayJsonapiSupport {
+  implicit def playJsonUnmarshaller[T: Reads] =
+    delegate[String, T](`application/json`, `application/vnd.api+json`)(string ⇒
+      try {
+        implicitly[Reads[T]].reads(Json.parse(string)).asEither.left.map(e ⇒ MalformedContent(s"Received JSON is not valid.\n${Json.prettyPrint(JsError.toFlatJson(e))}"))
+      } catch {
+        case NonFatal(exc) ⇒ Left(MalformedContent(exc.getMessage, exc))
+      })(UTF8StringUnmarshaller)
+
+  implicit def playJsonMarshaller[T: Writes](implicit printer: JsValue ⇒ String = Json.stringify) =
+    Marshaller.delegate[T, String](ContentTypes.`application/json`, ContentType(MediaTypes.`application/vnd.api+json`, HttpCharsets.`UTF-8`)) { value ⇒
+      printer(implicitly[Writes[T]].writes(value))
+    }
+
+  //
+  private val UTF8StringUnmarshaller = new Unmarshaller[String] {
+    def apply(entity: HttpEntity) = Right(entity.asString(defaultCharset = HttpCharsets.`UTF-8`))
+  }
+
+  // Unmarshaller.delegate is used as a kind of map operation; play-json JsResult can contain either validation errors or the JsValue
+  // representing a JSON object. We need a delegate method that works as a flatMap and let the provided A ⇒ Deserialized[B] function
+  // to deal with any possible error, including exceptions.
+  //
+  private def delegate[A, B](unmarshalFrom: ContentTypeRange*)(f: A ⇒ Deserialized[B])(implicit ma: Unmarshaller[A]): Unmarshaller[B] =
+    new SimpleUnmarshaller[B] {
+      val canUnmarshalFrom = unmarshalFrom
+      def unmarshal(entity: HttpEntity) = ma(entity).right.flatMap(a ⇒ f(a))
+    }
+}
+
+trait PlayJsonJsonapiSupport extends PlayJsonJsonapiFormat with PlayJsonapiSupport {
+
   implicit val playJsonJsonapiMarshaller =
     Marshaller.delegate[RootObject, JsValue](`application/vnd.api+json`)(Json.toJson(_))
 

--- a/src/test/scala/org/zalando/jsonapi/json/JsonapiSupportSpec.scala
+++ b/src/test/scala/org/zalando/jsonapi/json/JsonapiSupportSpec.scala
@@ -33,18 +33,17 @@ trait JsonapiSupportSpec extends WordSpec with TypeCheckedTripleEquals with Eith
         """HttpEntity(application/vnd.api+json; charset=UTF-8,{"jsonapi":{"foo":"bar"}})""")
     }
 
-    // TODO Fix Play framework unmarshalling problem (issue #25 on github)
-    //    "allow unmarshalling a Json to a root object with the correct content type" in new Context {
-    //      val httpEntity = HttpEntity(`application/vnd.api+json`, """{"jsonapi":{"foo":"bar"}}""")
-    //      assert(httpEntity.as[RootObject] === Right(rootObject))
-    //    }
-    //
-    //    "allow unmarshalling Jsonapi root object to a value type" in new Context {
-    //      implicit val fooReader = new JsonapiRootObjectReader[Foo] {
-    //        override def fromJsonapi(ro: RootObject) = foo
-    //      }
-    //      val httpEntity = HttpEntity(`application/vnd.api+json`, """{"jsonapi":{"foo":"bar"}}""")
-    //      assert(httpEntity.as[Foo] === Right(foo))
-    //    }
+    "allow unmarshalling a Json to a root object with the correct content type" in new Context {
+      val httpEntity = HttpEntity(`application/vnd.api+json`, """{"jsonapi":{"foo":"bar"}}""")
+      assert(httpEntity.as[RootObject] === Right(rootObject))
+    }
+
+    "allow unmarshalling Jsonapi root object to a value type" in new Context {
+      implicit val fooReader = new JsonapiRootObjectReader[Foo] {
+        override def fromJsonapi(ro: RootObject) = foo
+      }
+      val httpEntity = HttpEntity(`application/vnd.api+json`, """{"jsonapi":{"foo":"bar"}}""")
+      assert(httpEntity.as[Foo] === Right(foo))
+    }
   }
 }


### PR DESCRIPTION
hi zmeda,

sorry for my english,
I think we need to use our own PlayJsonSupport marshaller because the default one provided by spray only support application/json ContentType

see: http://stackoverflow.com/questions/21362198/spray-io-mapping-request-from-text-json-to-application-json

I also remove a "non exhaustive match warning" on playJsonapiFormatter for links. 
(all links that not match spec will be ignored)

sincerly,

Jeremie
