### PR TITLE
Allow links of any names

### DIFF
--- a/src/main/scala/org/zalando/jsonapi/json/playjson/PlayJsonJsonapiFormat.scala
+++ b/src/main/scala/org/zalando/jsonapi/json/playjson/PlayJsonJsonapiFormat.scala
@@ -205,31 +205,15 @@ trait PlayJsonJsonapiFormat {
    */
   implicit lazy val linksFormat: Format[Links] = new Format[Links] {
     override def writes(links: Links): JsValue = {
-      val fields = links.map {
-        _ match {
-          case Links.About(u)   ⇒ (FieldNames.`about`, JsString(u))
-          case Links.First(u)   ⇒ (FieldNames.`first`, JsString(u))
-          case Links.Last(u)    ⇒ (FieldNames.`last`, JsString(u))
-          case Links.Next(u)    ⇒ (FieldNames.`next`, JsString(u))
-          case Links.Prev(u)    ⇒ (FieldNames.`prev`, JsString(u))
-          case Links.Related(u) ⇒ (FieldNames.`related`, JsString(u))
-          case Links.Self(u)    ⇒ (FieldNames.`self`, JsString(u))
-        }
+      val fields = links.map { l =>
+        (l.name, JsString(l.url))
       }
       JsObject(fields)
     }
 
     override def reads(json: JsValue): JsResult[Links] = json match {
       case JsObject(o) ⇒ JsSuccess(o.map { keyValue ⇒
-        keyValue match {
-          case (FieldNames.`about`, JsString(u))   ⇒ Links.About(u)
-          case (FieldNames.`first`, JsString(u))   ⇒ Links.First(u)
-          case (FieldNames.`last`, JsString(u))    ⇒ Links.Last(u)
-          case (FieldNames.`next`, JsString(u))    ⇒ Links.Next(u)
-          case (FieldNames.`prev`, JsString(u))    ⇒ Links.Prev(u)
-          case (FieldNames.`related`, JsString(u)) ⇒ Links.Related(u)
-          case (FieldNames.`self`, JsString(u))    ⇒ Links.Self(u)
-        }
+        Link(keyValue._1, keyValue._2.as[JsString].value)
       }.toVector)
       case _ ⇒ JsError("error.expected.links")
     }

--- a/src/main/scala/org/zalando/jsonapi/model/package.scala
+++ b/src/main/scala/org/zalando/jsonapi/model/package.scala
@@ -1,6 +1,5 @@
 package org.zalando.jsonapi
 
-import org.zalando.jsonapi.model.Links.Link
 import org.zalando.jsonapi.model.RootObject.ResourceObjects
 
 import scala.collection.immutable.{ Seq ⇒ ImmutableSeq }
@@ -47,53 +46,11 @@ package object model {
   type Links = ImmutableSeq[Link]
 
   /**
-   * Companion object for links.
-   */
-  object Links {
-    sealed trait Link
-
-    /**
-     * A link of the "self" type.
-     * @param url The url to link to.
-     */
-    case class Self(url: String) extends Link
-
-    /**
-     * A link of the "related" type.
-     * @param url The url to link to.
-     */
-    case class Related(url: String) extends Link
-
-    /**
-     * A link of the "first" type.
-     * @param url The url to link to.
-     */
-    case class First(url: String) extends Link
-
-    /**
-     * A link of the "last" type.
-     * @param url The url to link to.
-     */
-    case class Last(url: String) extends Link
-
-    /**
-     * A link of the "next" type.
-     * @param url The url to link to.
-     */
-    case class Next(url: String) extends Link
-
-    /**
-     * A link of the "prev" type.
-     * @param url The url to link to.
-     */
-    case class Prev(url: String) extends Link
-
-    /**
-     * A link of the "about" type.
-     * @param url The url to link to.
-     */
-    case class About(url: String) extends Link
-  }
+    * The representation of the link
+    * @param name the name of the link, for example "self"
+    * @param url the value of the URL where link is pointing to
+    */
+  case class Link(name: String, url: String)
 
   /**
    * A collection of [[Attribute]] objects.

--- a/src/test/scala/org/zalando/jsonapi/json/ExampleSpec.scala
+++ b/src/test/scala/org/zalando/jsonapi/json/ExampleSpec.scala
@@ -1,11 +1,11 @@
 package org.zalando.jsonapi.json
 
-import org.scalatest.{ MustMatchers, WordSpec }
-import org.zalando.jsonapi.json.sprayjson.{ SprayJsonJsonapiProtocol, SprayJsonJsonapiProtocol$ }
-import org.zalando.jsonapi.{ JsonapiRootObjectWriter, _ }
+import org.scalatest.{MustMatchers, WordSpec}
+import org.zalando.jsonapi.json.sprayjson.{SprayJsonJsonapiProtocol, SprayJsonJsonapiProtocol$}
+import org.zalando.jsonapi.{JsonapiRootObjectWriter, _}
 import org.zalando.jsonapi.model.JsonApiObject.StringValue
 import org.zalando.jsonapi.model.RootObject.ResourceObject
-import org.zalando.jsonapi.model.{ Attribute, Links, RootObject }
+import org.zalando.jsonapi.model.{Attribute, Link, Links, RootObject}
 import spray.json._
 
 class ExampleSpec extends WordSpec with MustMatchers with SprayJsonJsonapiProtocol {
@@ -52,7 +52,7 @@ class ExampleSpec extends WordSpec with MustMatchers with SprayJsonJsonapiProtoc
             id = Some(person.id.toString),
             attributes = Some(List(
               Attribute("name", StringValue(person.name))
-            )), links = Some(List(Links.Self("http://test.link/person/42"))))))
+            )), links = Some(List(Link("self", "http://test.link/person/42"))))))
         }
       }
 
@@ -85,7 +85,7 @@ class ExampleSpec extends WordSpec with MustMatchers with SprayJsonJsonapiProtoc
             id = Some(person.id.toString),
             attributes = Some(List(
               Attribute("name", StringValue(person.name))
-            )))), links = Some(List(Links.Next("http://test.link/person/43"))))
+            )))), links = Some(List(Link("next", "http://test.link/person/43"))))
         }
       }
 

--- a/src/test/scala/org/zalando/jsonapi/json/JsonBaseSpec.scala
+++ b/src/test/scala/org/zalando/jsonapi/json/JsonBaseSpec.scala
@@ -101,9 +101,9 @@ trait JsonBaseSpec[JsonBaseType] extends WordSpec {
         ResourceObject(
           `type` = "person",
           attributes = Some(List(Attribute("name", StringValue("foobar")))),
-          links = Some(List(Links.Self("/persons/1")))
+          links = Some(List(Link("self", "/persons/1")))
         )))),
-      links = Some(List(Links.Next("/persons/2")))
+      links = Some(List(Link("next", "/persons/2")))
     )
 
   protected lazy val rootObjectWithResourceIdentifierObjectJsonString =
@@ -161,13 +161,13 @@ trait JsonBaseSpec[JsonBaseType] extends WordSpec {
   protected lazy val rootObjectWithResourceObjectsWithAllLinks = RootObject(Some(ResourceObjects(List(
     ResourceObject(`type` = "person", links = Some(
       List(
-        Links.Self("/persons/2"),
-        Links.Related("/persons/10"),
-        Links.Next("/persons/3"),
-        Links.Prev("/persons/1"),
-        Links.About("/persons/11"),
-        Links.First("/persons/0"),
-        Links.Last("/persons/99")
+        Link("self", "/persons/2"),
+        Link("related", "/persons/10"),
+        Link("next", "/persons/3"),
+        Link("prev", "/persons/1"),
+        Link("about", "/persons/11"),
+        Link("first", "/persons/0"),
+        Link("last", "/persons/99")
       )))))))
 
   protected lazy val rootObjectWithResourceObjectsWithMetaJsonString =
@@ -246,7 +246,7 @@ trait JsonBaseSpec[JsonBaseType] extends WordSpec {
       data = None,
       errors = Some(List(Error(
         id = Some("1"),
-        links = Some(List(Links.Self("self-link"))),
+        links = Some(List(Link("self", "self-link"))),
         status = Some("status1"),
         code = Some("code1"),
         title = Some("title1"),
@@ -351,7 +351,7 @@ trait JsonBaseSpec[JsonBaseType] extends WordSpec {
           relationships =
             Some(Map("father" -> Relationship(
               data = Some(ResourceObject(`type` = "person")),
-              links = Some(List(Links.Self("http://link.to.self")))
+              links = Some(List(Link("self", "http://link.to.self")))
             )))
         )
       ))
@@ -384,7 +384,7 @@ trait JsonBaseSpec[JsonBaseType] extends WordSpec {
     relationships =
       Some(Map("father" -> Relationship(
         data = Some(ResourceObject(`type` = "person")),
-        links = Some(List(Links.Self("http://link.to.self")))
+        links = Some(List(Link("self", "http://link.to.self")))
       )))
   )
 
@@ -405,7 +405,7 @@ trait JsonBaseSpec[JsonBaseType] extends WordSpec {
   protected lazy val relationshipsObject = Map(
     "father" -> Relationship(
       data = Some(ResourceObject(`type` = "person")),
-      links = Some(List(Links.Self("http://link.to.self")))
+      links = Some(List(Link("self", "http://link.to.self")))
     )
   )
 


### PR DESCRIPTION
Fixes issue #35 
Instead of using sealed trait, using case classes - the same approach is used for `Attribute`

I'd like to get some feedback on this issue and and some rough estimate when this could be released (if nothing is broken)