### PR TITLE
ResourceObjects can have links with any name

### DIFF
--- a/src/main/scala/org/zalando/jsonapi/json/playjson/PlayJsonJsonapiFormat.scala
+++ b/src/main/scala/org/zalando/jsonapi/json/playjson/PlayJsonJsonapiFormat.scala
@@ -50,9 +50,27 @@ trait PlayJsonJsonapiFormat {
     (JsPath \ FieldNames.`id`).formatNullable[String] and
     (JsPath \ FieldNames.`attributes`).formatNullable[Attributes] and
     (JsPath \ FieldNames.`relationships`).formatNullable[Relationships] and
-    (JsPath \ FieldNames.`links`).formatNullable[Links] and
+    (JsPath \ FieldNames.`links`).formatNullable[ResourceLinks] and
     (JsPath \ FieldNames.`meta`).formatNullable[Meta]
   )(ResourceObject.apply, unlift(ResourceObject.unapply))
+
+  /**
+   * Play-JSON format for serializing and deserializing Jsonapi [[ResourceLinks]].
+   */
+  implicit lazy val resourceLinksFormat: Format[ResourceLinks] = new Format[ResourceLinks] {
+    override def writes(links: ResourceLinks): JsValue = {
+      val fields = links.map { l ⇒
+        (l.name, JsString(l.url))
+      }
+      JsObject(fields)
+    }
+    override def reads(json: JsValue): JsResult[ResourceLinks] = json match {
+      case JsObject(o) ⇒ JsSuccess(o.map { keyValue ⇒
+        ResourceLink(keyValue._1, keyValue._2.as[JsString].value)
+      }.toVector)
+      case _ ⇒ JsError("error.expected.links")
+    }
+  }
 
   /**
    * Play-JSON format for serializing and deserializing Jsonapi [[Attributes]].

--- a/src/main/scala/org/zalando/jsonapi/json/sprayjson/SprayJsonJsonapiFormat.scala
+++ b/src/main/scala/org/zalando/jsonapi/json/sprayjson/SprayJsonJsonapiFormat.scala
@@ -77,10 +77,27 @@ trait SprayJsonJsonapiFormat {
       val `type` = (obj \ FieldNames.`type`).asString
       val id = (obj \? FieldNames.`id`) map (_.asString)
       val attributes = (obj \? FieldNames.`attributes`) map (_.convertTo[Attributes])
-      val links = (obj \? FieldNames.`links`) map (_.convertTo[Links])
+      val links = (obj \? FieldNames.`links`) map (_.convertTo[ResourceLinks])
       val meta = (obj \? FieldNames.`meta`) map (_.convertTo[Meta])
       val relationships = (obj \? FieldNames.`relationships`) map (_.convertTo[Relationships])
       ResourceObject(`type`, id, attributes, relationships, links, meta)
+    }
+  }
+
+  /**
+   * Spray-JSON format for serializing and deserializing Jsonapi [[ResourceLinks]].
+   */
+  implicit lazy val resourceLinksFormat: RootJsonFormat[ResourceLinks] = new RootJsonFormat[ResourceLinks] {
+    override def write(links: ResourceLinks): JsValue = {
+      links.map {
+        l ⇒ l.name -> l.url.toJson
+      }.toMap.toJson
+    }
+    override def read(json: JsValue): ResourceLinks = {
+      val obj = json.asJsObject
+      obj.fields.map{
+        o ⇒ ResourceLink(o._1, o._2.asString)
+      }.toVector
     }
   }
 

--- a/src/main/scala/org/zalando/jsonapi/model/package.scala
+++ b/src/main/scala/org/zalando/jsonapi/model/package.scala
@@ -32,7 +32,7 @@ package object model {
       id: Option[String] = None,
       attributes: Option[Attributes] = None,
       relationships: Option[Relationships] = None,
-      links: Option[Links] = None,
+      links: Option[ResourceLinks] = None,
       meta: Option[Meta] = None) extends Data
 
     /**
@@ -94,6 +94,10 @@ package object model {
      */
     case class About(url: String) extends Link
   }
+
+  type ResourceLinks = ImmutableSeq[ResourceLink]
+
+  case class ResourceLink(name: String, url: String)
 
   /**
    * A collection of [[Attribute]] objects.

--- a/src/test/scala/org/zalando/jsonapi/json/ExampleSpec.scala
+++ b/src/test/scala/org/zalando/jsonapi/json/ExampleSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.{ MustMatchers, WordSpec }
 import org.zalando.jsonapi.json.sprayjson.SprayJsonJsonapiProtocol
 import org.zalando.jsonapi.model.JsonApiObject.StringValue
 import org.zalando.jsonapi.model.RootObject.ResourceObject
-import org.zalando.jsonapi.model.{ Attribute, Links, RootObject }
+import org.zalando.jsonapi.model.{ Attribute, Links, ResourceLink, RootObject }
 import org.zalando.jsonapi.{ JsonapiRootObjectWriter, _ }
 import spray.json._
 
@@ -52,7 +52,7 @@ class ExampleSpec extends WordSpec with MustMatchers with SprayJsonJsonapiProtoc
             id = Some(person.id.toString),
             attributes = Some(List(
               Attribute("name", StringValue(person.name))
-            )), links = Some(List(Links.Self("http://test.link/person/42"))))))
+            )), links = Some(List(ResourceLink("self", "http://test.link/person/42"))))))
         }
       }
 

--- a/src/test/scala/org/zalando/jsonapi/json/JsonBaseSpec.scala
+++ b/src/test/scala/org/zalando/jsonapi/json/JsonBaseSpec.scala
@@ -18,6 +18,8 @@ trait JsonBaseSpec[JsonBaseType] extends WordSpec {
 
   protected lazy val rootObjectWithResourceIdentifierObjectsJson = parseJson(rootObjectWithResourceIdentifierObjectsJsonString)
 
+  protected lazy val rootObjectWithLinksJson = parseJson(rootObjectWithLinksJsonString)
+
   protected lazy val rootObjectWithResourceObjectsWithAllLinksJson = parseJson(rootObjectWithResourceObjectsWithAllLinksJsonString)
 
   protected lazy val rootObjectWithResourceObjectsWithMetaJson = parseJson(rootObjectWithResourceObjectsWithMetaJsonString)
@@ -101,7 +103,7 @@ trait JsonBaseSpec[JsonBaseType] extends WordSpec {
         ResourceObject(
           `type` = "person",
           attributes = Some(List(Attribute("name", StringValue("foobar")))),
-          links = Some(List(Links.Self("/persons/1")))
+          links = Some(List(ResourceLink("self", "/persons/1")))
         )))),
       links = Some(List(Links.Next("/persons/2")))
     )
@@ -140,6 +142,36 @@ trait JsonBaseSpec[JsonBaseType] extends WordSpec {
       ResourceObject(`type` = "cat", id = Some("felix"))
     ))))
 
+  protected lazy val rootObjectWithLinksJsonString =
+    """
+      |{
+      |  "data": [{
+      |    "type": "list"
+      |    }],
+      |  "links": {
+      |    "self": "/persons/2",
+      |    "related": "/persons/10",
+      |    "next": "/persons/3",
+      |    "prev": "/persons/1",
+      |    "about": "/persons/11",
+      |    "first": "/persons/0",
+      |    "last": "/persons/99"
+      |  }
+      |}
+    """.stripMargin
+
+  protected lazy val rootObjectWithLinks = RootObject(
+    data = Some(ResourceObjects(List(ResourceObject(`type` = "list")))),
+    links = Some(List(
+      Links.Self("/persons/2"),
+      Links.Related("/persons/10"),
+      Links.Next("/persons/3"),
+      Links.Prev("/persons/1"),
+      Links.About("/persons/11"),
+      Links.First("/persons/0"),
+      Links.Last("/persons/99")
+    )))
+
   protected lazy val rootObjectWithResourceObjectsWithAllLinksJsonString =
     """
       |{
@@ -147,27 +179,17 @@ trait JsonBaseSpec[JsonBaseType] extends WordSpec {
       |    "type": "person",
       |    "links": {
       |      "self": "/persons/2",
-      |      "related": "/persons/10",
-      |      "next": "/persons/3",
-      |      "prev": "/persons/1",
-      |      "about": "/persons/11",
-      |      "first": "/persons/0",
-      |      "last": "/persons/99"
+      |      "friend": "/persons/10"
       |    }
       |  }]
       |}
     """.stripMargin
 
-  protected lazy val rootObjectWithResourceObjectsWithAllLinks = RootObject(Some(ResourceObjects(List(
+  protected lazy val rootObjectWithResourceObjectsWithLinks = RootObject(Some(ResourceObjects(List(
     ResourceObject(`type` = "person", links = Some(
       List(
-        Links.Self("/persons/2"),
-        Links.Related("/persons/10"),
-        Links.Next("/persons/3"),
-        Links.Prev("/persons/1"),
-        Links.About("/persons/11"),
-        Links.First("/persons/0"),
-        Links.Last("/persons/99")
+        ResourceLink("self", "/persons/2"),
+        ResourceLink("friend", "/persons/10")
       )))))))
 
   protected lazy val rootObjectWithResourceObjectsWithMetaJsonString =

--- a/src/test/scala/org/zalando/jsonapi/json/playjson/PlayJsonJsonapiFormatSpec.scala
+++ b/src/test/scala/org/zalando/jsonapi/json/playjson/PlayJsonJsonapiFormatSpec.scala
@@ -27,8 +27,11 @@ class PlayJsonJsonapiFormatSpec extends JsonBaseSpec[JsValue] with MustMatchers 
       "transform a list of resource identifier objects correctly" in {
         Json.toJson(rootObjectWithResourceIdentifierObjects) mustEqual rootObjectWithResourceIdentifierObjectsJson
       }
-      "transform all link types correctly" in {
-        Json.toJson(rootObjectWithResourceObjectsWithAllLinks) mustEqual rootObjectWithResourceObjectsWithAllLinksJson
+      "transform root link types correctly" in {
+        Json.toJson(rootObjectWithLinks) mustEqual rootObjectWithLinksJson
+      }
+      "transform resource link types correctly" in {
+        Json.toJson(rootObjectWithResourceObjectsWithLinks) mustEqual rootObjectWithResourceObjectsWithAllLinksJson
       }
       "transform all meta object inside resource object correctly" in {
         Json.toJson(rootObjectWithResourceObjectsWithMeta) mustEqual rootObjectWithResourceObjectsWithMetaJson
@@ -71,8 +74,11 @@ class PlayJsonJsonapiFormatSpec extends JsonBaseSpec[JsValue] with MustMatchers 
       "transform a list of resource identifier objects correctly" in {
         Json.fromJson[RootObject](rootObjectWithResourceIdentifierObjectsJson) mustEqual JsSuccess(rootObjectWithResourceIdentifierObjects)
       }
-      "transform all link types correctly" in {
-        Json.fromJson[RootObject](rootObjectWithResourceObjectsWithAllLinksJson) mustEqual JsSuccess(rootObjectWithResourceObjectsWithAllLinks)
+      "transform root link types correctly" in {
+        Json.fromJson[RootObject](rootObjectWithLinksJson) mustEqual JsSuccess(rootObjectWithLinks)
+      }
+      "transform resource link types correctly" in {
+        Json.fromJson[RootObject](rootObjectWithResourceObjectsWithAllLinksJson) mustEqual JsSuccess(rootObjectWithResourceObjectsWithLinks)
       }
       "transform all meta object inside resource object correctly" in {
         Json.fromJson[RootObject](rootObjectWithResourceObjectsWithMetaJson) mustEqual JsSuccess(rootObjectWithResourceObjectsWithMeta)

--- a/src/test/scala/org/zalando/jsonapi/json/sprayjson/SprayJsonJsonapiFormatSpec.scala
+++ b/src/test/scala/org/zalando/jsonapi/json/sprayjson/SprayJsonJsonapiFormatSpec.scala
@@ -26,8 +26,11 @@ class SprayJsonJsonapiFormatSpec extends JsonBaseSpec[JsValue] with MustMatchers
       "transform a list of resource identifier objects correctly" in {
         rootObjectWithResourceIdentifierObjects.toJson mustEqual rootObjectWithResourceIdentifierObjectsJson
       }
-      "transform all link types correctly" in {
-        rootObjectWithResourceObjectsWithAllLinks.toJson mustEqual rootObjectWithResourceObjectsWithAllLinksJson
+      "transform root link types correctly" in {
+        rootObjectWithLinks.toJson mustEqual rootObjectWithLinksJson
+      }
+      "transform resource link types correctly" in {
+        rootObjectWithResourceObjectsWithLinks.toJson mustEqual rootObjectWithResourceObjectsWithAllLinksJson
       }
       "transform all meta object inside resource object correctly" in {
         rootObjectWithResourceObjectsWithMeta.toJson mustEqual rootObjectWithResourceObjectsWithMetaJson
@@ -70,8 +73,11 @@ class SprayJsonJsonapiFormatSpec extends JsonBaseSpec[JsValue] with MustMatchers
       "transform a list of resource identifier objects correctly" in {
         rootObjectWithResourceIdentifierObjectsJson.convertTo[RootObject] === rootObjectWithResourceIdentifierObjects
       }
-      "transform all link types correctly" in {
-        rootObjectWithResourceObjectsWithAllLinksJson.convertTo[RootObject] === rootObjectWithResourceObjectsWithAllLinks
+      "transform root link types correctly" in {
+        rootObjectWithLinksJson.convertTo[RootObject] === rootObjectWithLinks
+      }
+      "transform resource link types correctly" in {
+        rootObjectWithResourceObjectsWithAllLinksJson.convertTo[RootObject] === rootObjectWithResourceObjectsWithLinks
       }
       "transform all meta object inside resource object correctly" in {
         rootObjectWithResourceObjectsWithMetaJson.convertTo[RootObject] === rootObjectWithResourceObjectsWithMeta


### PR DESCRIPTION
Specification list allowed link types for root objects, but resource objects can have links with any name, my change introduces `ResourceLink` case class that fixes that. I have added tests

addresses #35