### PR TITLE
added AkkaHttpJsonapiSupport - Java 1.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ libraryDependencies ++= Seq(
   "io.spray"          %% "spray-httpx" % "1.3.3"  % "provided",
   "com.typesafe.akka" %% "akka-actor"  % "2.3.6"  % "provided",
   "com.typesafe.play" %% "play-json"   % "2.3.8"  % "provided",
-  "com.typesafe.akka" %% "akka-http-spray-json-experimental" % "2.4.4" % "provided",
+  "com.typesafe.akka" %% "akka-http-spray-json-experimental" % "2.0.4" % "provided",
   "org.scalatest"     %% "scalatest"   % "2.2.4"  % "test"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,7 @@ libraryDependencies ++= Seq(
   "io.spray"          %% "spray-httpx" % "1.3.3"  % "provided",
   "com.typesafe.akka" %% "akka-actor"  % "2.3.6"  % "provided",
   "com.typesafe.play" %% "play-json"   % "2.3.8"  % "provided",
+  "com.typesafe.akka" %% "akka-http-spray-json-experimental" % "2.4.4" % "provided",
   "org.scalatest"     %% "scalatest"   % "2.2.4"  % "test"
 )
 

--- a/src/main/scala/org/zalando/jsonapi/json/sprayjson/AkkaHttpJsonapiSupport.scala
+++ b/src/main/scala/org/zalando/jsonapi/json/sprayjson/AkkaHttpJsonapiSupport.scala
@@ -1,0 +1,22 @@
+package org.zalando.jsonapi.json.sprayjson
+
+import akka.http.scaladsl.marshalling.{ ToEntityMarshaller, Marshaller }
+import org.zalando.jsonapi.model.RootObject
+import spray.json._
+import akka.http.scaladsl.model.MediaTypes.`application/vnd.api+json`
+import akka.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshaller }
+
+trait AkkaHttpJsonapiSupport extends SprayJsonJsonapiFormat with DefaultJsonProtocol {
+  implicit def akkaHttpJsonJsonapiMarshaller(implicit printer: JsonPrinter = PrettyPrinter): ToEntityMarshaller[RootObject] = {
+    Marshaller.StringMarshaller.wrap(`application/vnd.api+json`)(printer).compose(_.toJson)
+  }
+
+  implicit def akkaHttpJsonJsonapiUnmarshaller: FromEntityUnmarshaller[RootObject] = {
+    Unmarshaller
+      .byteStringUnmarshaller
+      .forContentTypes(`application/vnd.api+json`)
+      .mapWithCharset((data, charset) ⇒ data.decodeString(charset.nioCharset.name).parseJson.convertTo[RootObject])
+  }
+}
+
+object AkkaHttpJsonapiSupport extends AkkaHttpJsonapiSupport


### PR DESCRIPTION
This is alternative to another PR: https://github.com/zalando/scala-jsonapi/pull/39

It seems that akka wasn't released with support for 1.7, only for 1.6