### PR TITLE
#29: Adds support for Akka Http (un)marshalling. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
-  - 2.11.7
+  - 2.11.8
 branches:
   only:
     - master
@@ -17,7 +17,7 @@ notifications:
     on_success: change
     on_failure: always
     on_start: never
-script: "sbt clean coverage +test"
+script: "sbt clean coverage test"
 after_success:
   - "sbt coveralls"
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: scala
+jdk:
+  - oraclejdk8
 scala:
   - 2.11.8
 branches:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Zalando SE
+Copyright (c) 2016 Zalando SE
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -5,21 +5,32 @@
 [![codecov.io](https://codecov.io/github/zalando/scala-jsonapi/coverage.svg?branch=master)](https://codecov.io/github/zalando/scala-jsonapi?branch=master)
 [![Join the chat at https://gitter.im/zalando/scala-jsonapi](https://badges.gitter.im/zalando/scala-jsonapi.svg)](https://gitter.im/zalando/scala-jsonapi?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-A Scala library for producing JSON output based on [JSON API specification](http://jsonapi.org/). 
+A Scala library for producing JSON output based on [JSON API specification][jsonapi]. 
 
 ## Current status
 
-The library supports read and write for both Play-JSON and Spray-JSON.
+The library supports read and write for following backends:
+
+ * [Play-JSON]
+ * [Spray-JSON]
+ * [Circe]
+ 
+Besides the supported backends, the library provides out-of-the-box (un)marshallers for:
+
+ * Spray and Play
+ * Akka Http
 
 Library is very much Work-In-Progress and expect API to change.
 
-Currently library supports Scala version `2.11` and `2.10`.
+Currently library supports Scala version `2.11`.
 
 # Setup
 
-In order to use current version _scala-jsonapi_ you have to add library dependency assuming that you have [sonatype resolvers](http://www.scala-sbt.org/0.13/docs/Resolvers.html#Maven) set up.
+In order to use current version _scala-jsonapi_ you have to add library dependency assuming that you have [sonatype resolvers] set up.
 
-    libraryDependencies += "org.zalando" %% "scala-jsonapi" % "0.4.1"
+    libraryDependencies += "org.zalando" %% "scala-jsonapi" % "0.5.0"
+
+As a dependency you have to provide also the used backend (e.g. spray-json).
 
 # Usage
 
@@ -74,8 +85,37 @@ Following code snippet demonstrate the usage of that:
     
     val personRootObject: RootObject = Jsonapi.asJsonapi(Person("Boris M."))
 
-For complete usage see [the specs example](src/test/scala/org/zalando/jsonapi/json/ExampleSpec.scala).
+In contrast there is a type class called `JsonapiRootEntityReader` which support to convert from JSON API representation to your resources.
+Following code snippet demonstrate the usage of that:
+
+    import org.zalando.jsonapi
+    import jsonapi.Jsonapi
+    
+    case class Person(name: String)
+    
+    implicit val personJsonapiReader = new JsonapiRootObjectReader[Person] {
+      override def fromJsonapi(rootObject: RootObject) = {
+        ???
+      }
+    }
+    
+    val person: Person = Jsonapi.fromJsonapi[Person](RootObject(...))
+
+For complete usage see [the specs example].
 
 # Publishing and Releasing
 
-Publishing and releasing is made with help of [sbt-sonatype plugin](https://github.com/xerial/sbt-sonatype)
+Publishing and releasing is made with help of [sbt-sonatype plugin]
+
+# License
+
+_scala-jsonapi_ is licensed under [MIT][MIT license].
+
+[sbt-sonatype plugin]: https://github.com/xerial/sbt-sonatype
+[the specs example]: src/test/scala/org/zalando/jsonapi/json/ExampleSpec.scala
+[sonatype resolvers]: http://www.scala-sbt.org/0.13/docs/Resolvers.html#Maven
+[jsonapi]: http://jsonapi.org/
+[Play-JSON]: https://www.playframework.com/documentation/2.5.x/ScalaJson
+[Spray-JSON]: https://github.com/spray/spray-json
+[Circe]: https://github.com/travisbrown/circe
+[MIT license]: https://opensource.org/licenses/MIT

--- a/build.sbt
+++ b/build.sbt
@@ -12,8 +12,6 @@ scalaVersion := "2.11.8"
 
 scalacOptions ++= Seq("-feature", "-unchecked", "-deprecation")
 
-crossScalaVersions := Seq("2.11.8", "2.10.6")
-
 resolvers ++= Seq(
   "spray" at "http://repo.spray.io/",
   "Typesafe Repo" at "http://repo.typesafe.com/typesafe/releases/"
@@ -21,16 +19,18 @@ resolvers ++= Seq(
 
 libraryDependencies ++= {
   val circeVersion = "0.5.0-M1"
+  val akkaVersion = "2.4.7"
 
   Seq(
-    "io.spray"          %% "spray-json"    % "1.3.2"      % "provided",
-    "io.spray"          %% "spray-httpx"   % "1.3.3"      % "provided",
-    "com.typesafe.akka" %% "akka-actor"    % "2.3.6"      % "provided",
-    "com.typesafe.play" %% "play-json"     % "2.3.8"      % "provided",
-    "io.circe"          %% "circe-core"    % circeVersion % "provided",
-    "io.circe"          %% "circe-generic" % circeVersion % "provided",
-    "io.circe"          %% "circe-parser"  % circeVersion % "provided",
-    "org.scalatest"     %% "scalatest"     % "2.2.4"      % "test"
+    "io.spray"          %% "spray-json"             % "1.3.2"      % "provided",
+    "io.spray"          %% "spray-httpx"            % "1.3.3"      % "provided",
+    "com.typesafe.akka" %% "akka-actor"             % akkaVersion  % "provided",
+    "com.typesafe.akka" %% "akka-http-experimental" % akkaVersion  % "provided",
+    "com.typesafe.play" %% "play-json"              % "2.3.8"      % "provided",
+    "io.circe"          %% "circe-core"             % circeVersion % "provided",
+    "io.circe"          %% "circe-generic"          % circeVersion % "provided",
+    "io.circe"          %% "circe-parser"           % circeVersion % "provided",
+    "org.scalatest"     %% "scalatest"              % "2.2.4"      % "test"
   )
 }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.11

--- a/src/main/scala/org/zalando/jsonapi/json/akka/http/AkkaHttpJsonapiSupport.scala
+++ b/src/main/scala/org/zalando/jsonapi/json/akka/http/AkkaHttpJsonapiSupport.scala
@@ -1,0 +1,23 @@
+package org.zalando.jsonapi.json.akka.http
+
+import akka.http.scaladsl.marshalling._
+import akka.http.scaladsl.model.HttpEntity
+import akka.http.scaladsl.model.MediaTypes._
+import akka.http.scaladsl.unmarshalling._
+import org.zalando.jsonapi.json.sprayjson.SprayJsonJsonapiProtocol
+import org.zalando.jsonapi.model._
+import org.zalando.jsonapi._
+import org.zalando.jsonapi.{ JsonapiRootObjectReader, JsonapiRootObjectWriter }
+import spray.json._
+
+trait AkkaHttpJsonapiSupport extends SprayJsonJsonapiProtocol with DefaultJsonProtocol {
+  def akkaHttpJsonapiMarshaller[T: JsonapiRootObjectWriter]: ToEntityMarshaller[T] =
+    Marshaller.withFixedContentType(`application/vnd.api+json`) { obj ⇒
+      HttpEntity(`application/vnd.api+json`, obj.rootObject.toJson.compactPrint)
+    }
+
+  def akkaHttpJsonapiUnmarshaller[T: JsonapiRootObjectReader]: FromEntityUnmarshaller[T] =
+    Unmarshaller.stringUnmarshaller.forContentTypes(`application/vnd.api+json`).map(_.parseJson.convertTo[RootObject].jsonapi[T])
+}
+
+object AkkaHttpJsonapiSupport extends AkkaHttpJsonapiSupport

--- a/src/test/scala/org/zalando/jsonapi/json/akka/http/AkkaHttpJsonapiSupportSpec.scala
+++ b/src/test/scala/org/zalando/jsonapi/json/akka/http/AkkaHttpJsonapiSupportSpec.scala
@@ -1,0 +1,35 @@
+package org.zalando.jsonapi.json.akka.http
+
+import org.scalactic.TypeCheckedTripleEquals
+import org.scalatest.{ EitherValues, WordSpec }
+import org.zalando.jsonapi.JsonapiRootObjectWriter
+import org.zalando.jsonapi.model._
+import org.zalando.jsonapi._
+import spray.json._
+
+class AkkaHttpJsonapiSupportSpec extends WordSpec with TypeCheckedTripleEquals with EitherValues with AkkaHttpJsonapiSupport {
+  s"AkkaHttpJsonapiSupport" must {
+    trait Context {
+      case class Foo(bar: String)
+      val rootObject = RootObject(jsonApi = Some(List(JsonApiProperty("foo", JsonApiObject.StringValue("bar")))))
+      val foo = Foo("bar")
+      val fooJson = """{"jsonapi":{"foo":"bar"}}"""
+    }
+
+    "allow marshalling a Jsonapi root object with the correct content type" in new Context {
+      val httpEntityString = """HttpEntity(application/vnd.api+json; charset=UTF-8,{"jsonapi":{"foo":"bar"}})"""
+      implicit val fooWriter = new JsonapiRootObjectWriter[Foo] {
+        override def toJsonapi(a: Foo) = rootObject
+      }
+
+      assert(foo.rootObject.toJson.compactPrint === fooJson)
+    }
+
+    "allow marshalling a value of a type that can be converted to a Jsonapi root object" in new Context {
+      implicit val fooReader = new JsonapiRootObjectReader[Foo] {
+        override def fromJsonapi(rootObject: RootObject) = foo
+      }
+      println(fooJson.parseJson.convertTo[RootObject].jsonapi[Foo] === foo)
+    }
+  }
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.2"
+version in ThisBuild := "0.5.0"


### PR DESCRIPTION
Also updating the build to only support Scala 2.11 and renew the readme.