### PR TITLE
implicit conversions for attributes and values

### DIFF
--- a/src/main/scala/org/zalando/jsonapi/model/implicits/AttributeConversions.scala
+++ b/src/main/scala/org/zalando/jsonapi/model/implicits/AttributeConversions.scala
@@ -1,0 +1,22 @@
+package org.zalando.jsonapi.model.implicits
+
+import scala.language.implicitConversions
+
+import org.zalando.jsonapi.model.Attribute
+import org.zalando.jsonapi.model.implicits.JsonApiObjectValueConversions._
+
+object AttributeConversions {
+  implicit def convertToStringAttribute(nameString: (String, String)) = Attribute(nameString._1, nameString._2)
+  implicit def convertToIntAttribute(nameInt: (String, Int)) = Attribute(nameInt._1, nameInt._2)
+  implicit def convertToLongAttribute(nameLong: (String, Long)) = Attribute(nameLong._1, nameLong._2)
+  implicit def convertToDoubleAttribute(nameDouble: (String, Double)) = Attribute(nameDouble._1, nameDouble._2)
+  implicit def convertToFloatAttribute(nameFloat: (String, Float)) = Attribute(nameFloat._1, nameFloat._2)
+  implicit def convertToBooleanAttribute(nameInt: (String, Boolean)) = Attribute(nameInt._1, nameInt._2)
+
+  implicit def convertToOptionalStringAttribute(nameString: (String, Option[String])) = nameString._2.map(nameString._1 -> _:Attribute)
+  implicit def convertToOptionalIntAttribute(nameInt: (String, Option[Int])) = nameInt._2.map(nameInt._1 -> _:Attribute)
+  implicit def convertToOptionalLongAttribute(nameLong: (String, Option[Long])) = nameLong._2.map(nameLong._1 -> _:Attribute)
+  implicit def convertToOptionalDoubleAttribute(nameDouble: (String, Option[Double])) = nameDouble._2.map(nameDouble._1 -> _:Attribute)
+  implicit def convertToOptionalFloatAttribute(nameFloat: (String, Option[Float])) = nameFloat._2.map(nameFloat._1 -> _:Attribute)
+  implicit def convertToOptionalBooleanAttribute(nameInt: (String, Option[Boolean])) = nameInt._2.map(nameInt._1 -> _:Attribute)
+}

--- a/src/main/scala/org/zalando/jsonapi/model/implicits/JsonApiObjectValueConversions.scala
+++ b/src/main/scala/org/zalando/jsonapi/model/implicits/JsonApiObjectValueConversions.scala
@@ -1,0 +1,14 @@
+package org.zalando.jsonapi.model.implicits
+
+import scala.language.implicitConversions
+
+import org.zalando.jsonapi.model.JsonApiObject._
+
+object JsonApiObjectValueConversions {
+  implicit def convertStringToStringValue(string: String) = StringValue(string)
+  implicit def convertIntToNumberValue(int: Int) = NumberValue(int)
+  implicit def convertLongToNumberValue(long: Long) = NumberValue(long)
+  implicit def convertDoubleToNumberValue(double: Double) = NumberValue(double)
+  implicit def convertFloatToNumberValue(float: Float) = NumberValue(float)
+  implicit def convertBooleanToBooleanValue(boolean: Boolean) = BooleanValue(boolean)
+}

--- a/src/test/scala/org/zalando/jsonapi/model/implicits/AttributeConversionsSpec.scala
+++ b/src/test/scala/org/zalando/jsonapi/model/implicits/AttributeConversionsSpec.scala
@@ -1,0 +1,38 @@
+package org.zalando.jsonapi.model.implicits
+
+import org.scalatest.{Matchers, WordSpec}
+import org.zalando.jsonapi.model.Attribute
+import org.zalando.jsonapi.model.JsonApiObject._
+import org.zalando.jsonapi.model.implicits.AttributeConversions._
+
+class AttributeConversionsSpec extends WordSpec with Matchers {
+  "scala tuples" should {
+    "be converted to string attributes" in {
+      convertToStringAttribute("name" -> "string") should be(Attribute("name", StringValue("string")))
+    }
+    "be converted to number attributes" in {
+      convertToIntAttribute("name" -> 42) should be(Attribute("name", NumberValue(42)))
+      convertToLongAttribute("name" -> 42l) should be(Attribute("name", NumberValue(42)))
+      convertToFloatAttribute("name" -> 42f) should be(Attribute("name", NumberValue(42)))
+      convertToDoubleAttribute("name" -> 42d) should be(Attribute("name", NumberValue(42)))
+    }
+    "be converted to boolean attributes" in {
+      convertToBooleanAttribute("name" -> true) should be(Attribute("name", BooleanValue(true)))
+      convertToBooleanAttribute("name" -> false) should be(Attribute("name", BooleanValue(false)))
+    }
+
+    "be converted to optional string attributes" in {
+      convertToOptionalStringAttribute("name" -> Option("string")) should be(Option(Attribute("name", StringValue("string"))))
+    }
+    "be converted to optional number attributes" in {
+      convertToOptionalIntAttribute("name" -> Option(42)) should be(Option(Attribute("name", NumberValue(42))))
+      convertToOptionalLongAttribute("name" -> Option(42l)) should be(Option(Attribute("name", NumberValue(42))))
+      convertToOptionalFloatAttribute("name" -> Option(42f)) should be(Option(Attribute("name", NumberValue(42))))
+      convertToOptionalDoubleAttribute("name" -> Option(42d)) should be(Option(Attribute("name", NumberValue(42))))
+    }
+    "be converted to optional boolean attributes" in {
+      convertToOptionalBooleanAttribute("name" -> Option(true)) should be(Option(Attribute("name", BooleanValue(true))))
+      convertToOptionalBooleanAttribute("name" -> Option(false)) should be(Option(Attribute("name", BooleanValue(false))))
+    }
+  }
+}

--- a/src/test/scala/org/zalando/jsonapi/model/implicits/JsonApiObjectValueConversionsSpec.scala
+++ b/src/test/scala/org/zalando/jsonapi/model/implicits/JsonApiObjectValueConversionsSpec.scala
@@ -1,0 +1,24 @@
+
+package org.zalando.jsonapi.model.implicits
+
+import org.scalatest.{Matchers, WordSpec}
+import org.zalando.jsonapi.model.JsonApiObject._
+import org.zalando.jsonapi.model.implicits.JsonApiObjectValueConversions._
+
+class JsonApiObjectValueConversionsSpec extends WordSpec with Matchers {
+  "scala values" should {
+    "be converted to string values" in {
+      convertStringToStringValue("string") should be(StringValue("string"))
+    }
+    "be converted to number values" in {
+      convertIntToNumberValue(42) should be(NumberValue(42))
+      convertLongToNumberValue(42l) should be(NumberValue(42))
+      convertFloatToNumberValue(42f) should be(NumberValue(42))
+      convertDoubleToNumberValue(42d) should be(NumberValue(42))
+    }
+    "be converted to boolean values" in {
+      convertBooleanToBooleanValue(true) should be(BooleanValue(true))
+      convertBooleanToBooleanValue(false) should be(BooleanValue(false))
+    }
+  }
+}


### PR DESCRIPTION
found myself doing
```scala
import org.zalando.jsonapi.model.Attribute
import org.zalando.jsonapi.model.JsonApiObject._

Attribute("name", StringValue("value"))
```
a lot, was nicer to just have this 
```scala
import org.zalando.jsonapi.model.implicits.AttributeConversions._

"name" -> "value"
```