### PR TITLE
#64: Fixed some of test compile errors

### DIFF
--- a/akka-http/src/main/scala/org/zalando/jsonapi/akka/http/AkkaHttpJsonapiSupport.scala
+++ b/akka-http/src/main/scala/org/zalando/jsonapi/akka/http/AkkaHttpJsonapiSupport.scala
@@ -6,7 +6,7 @@ import akka.http.scaladsl.unmarshalling._
 import org.zalando.jsonapi.model._
 import org.zalando.jsonapi.sprayjson.SprayJsonJsonapiProtocol
 import org.zalando.jsonapi.{JsonapiRootObjectReader, JsonapiRootObjectWriter, _}
-import spray.json._
+import _root_.spray.json._
 
 trait AkkaHttpJsonapiSupport extends SprayJsonJsonapiProtocol {
   def akkaHttpJsonapiMarshaller[T: JsonapiRootObjectWriter]: ToEntityMarshaller[T] =

--- a/akka-http/src/test/scala/org/zalando/jsonapi/akka/http/AkkaHttpJsonapiSupportSpec.scala
+++ b/akka-http/src/test/scala/org/zalando/jsonapi/akka/http/AkkaHttpJsonapiSupportSpec.scala
@@ -5,8 +5,7 @@ import org.scalatest.{EitherValues, WordSpec}
 import org.zalando.jsonapi.JsonapiRootObjectWriter
 import org.zalando.jsonapi.model._
 import org.zalando.jsonapi._
-import org.zalando.jsonapi.akka.http.AkkaHttpJsonapiSupport
-import spray.json._
+import _root_.spray.json._
 
 class AkkaHttpJsonapiSupportSpec extends WordSpec with TypeCheckedTripleEquals with EitherValues with AkkaHttpJsonapiSupport {
   s"AkkaHttpJsonapiSupport" must {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,5 +31,5 @@ object Dependencies {
 
   lazy val sprayJsonDeps = Seq(sprayJson)
 
-  lazy val akkaHttpDeps = Seq(akkaHttpCore, akkaHttpExperimental, sprayJson)
+  lazy val akkaHttpDeps = Seq(akkaHttpCore, akkaHttpExperimental, akkaHttpTestkit, sprayJson)
 }

--- a/spray-json/src/test/scala/org/zalando/jsonapi/sprayjson/ExampleSpec.scala
+++ b/spray-json/src/test/scala/org/zalando/jsonapi/sprayjson/ExampleSpec.scala
@@ -1,12 +1,12 @@
-package org.zalando.jsonapi.json
+package org.zalando.jsonapi.sprayjson
 
 import org.scalatest.{MustMatchers, WordSpec}
 import org.zalando.jsonapi.model.JsonApiObject.StringValue
 import org.zalando.jsonapi.model.RootObject.ResourceObject
 import org.zalando.jsonapi.model.{Attribute, Links, RootObject}
-import org.zalando.jsonapi.sprayjson.SprayJsonJsonapiProtocol
 import org.zalando.jsonapi.{JsonapiRootObjectWriter, _}
-import spray.json._
+import _root_.spray.json._
+import org.zalando.jsonapi.json.Person
 
 class ExampleSpec extends WordSpec with MustMatchers with SprayJsonJsonapiProtocol {
   "JsonapiRootObject" when {


### PR DESCRIPTION
- Ensured that absolute imports are used for `spray.json` instead of relative
  imports possibly refering to org.zalando.jsonapi packages.
- Updated missing dependency

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zalando/scala-jsonapi/84)
<!-- Reviewable:end -->
