### PR TITLE
fixe #25

### DIFF
--- a/src/main/scala/org/zalando/jsonapi/json/playjson/PlayJsonJsonapiSupport.scala
+++ b/src/main/scala/org/zalando/jsonapi/json/playjson/PlayJsonJsonapiSupport.scala
@@ -1,13 +1,45 @@
 package org.zalando.jsonapi.json.playjson
 
-import spray.httpx.PlayJsonSupport
-import spray.httpx.marshalling.Marshaller
-import spray.httpx.unmarshalling.Unmarshaller
 import org.zalando.jsonapi.model.RootObject
-import play.api.libs.json.{JsValue, Json}
-import spray.http.MediaTypes.`application/vnd.api+json`
+import play.api.libs.json._
+import spray.http.MediaTypes._
+import spray.http._
+import spray.httpx.marshalling.Marshaller
+import spray.httpx.unmarshalling._
 
-trait PlayJsonJsonapiSupport extends PlayJsonJsonapiFormat with PlayJsonSupport {
+import scala.util.control.NonFatal
+
+trait PlayJsonapiSupport {
+  implicit def playJsonUnmarshaller[T: Reads] =
+    delegate[String, T](`application/json`, `application/vnd.api+json`)(string ⇒
+      try {
+        implicitly[Reads[T]].reads(Json.parse(string)).asEither.left.map(e ⇒ MalformedContent(s"Received JSON is not valid.\n${Json.prettyPrint(JsError.toFlatJson(e))}"))
+      } catch {
+        case NonFatal(exc) ⇒ Left(MalformedContent(exc.getMessage, exc))
+      })(UTF8StringUnmarshaller)
+
+  implicit def playJsonMarshaller[T: Writes](implicit printer: JsValue ⇒ String = Json.stringify) =
+    Marshaller.delegate[T, String](ContentTypes.`application/json`, ContentType(MediaTypes.`application/vnd.api+json`, HttpCharsets.`UTF-8`)) { value ⇒
+      printer(implicitly[Writes[T]].writes(value))
+    }
+
+  //
+  private val UTF8StringUnmarshaller = new Unmarshaller[String] {
+    def apply(entity: HttpEntity) = Right(entity.asString(defaultCharset = HttpCharsets.`UTF-8`))
+  }
+
+  // Unmarshaller.delegate is used as a kind of map operation; play-json JsResult can contain either validation errors or the JsValue
+  // representing a JSON object. We need a delegate method that works as a flatMap and let the provided A ⇒ Deserialized[B] function
+  // to deal with any possible error, including exceptions.
+  //
+  private def delegate[A, B](unmarshalFrom: ContentTypeRange*)(f: A ⇒ Deserialized[B])(implicit ma: Unmarshaller[A]): Unmarshaller[B] =
+    new SimpleUnmarshaller[B] {
+      val canUnmarshalFrom = unmarshalFrom
+      def unmarshal(entity: HttpEntity) = ma(entity).right.flatMap(a ⇒ f(a))
+    }
+}
+
+trait PlayJsonJsonapiSupport extends PlayJsonJsonapiFormat with PlayJsonapiSupport {
 
   implicit val playJsonJsonapiMarshaller =
     Marshaller.delegate[RootObject, JsValue](`application/vnd.api+json`)(Json.toJson(_))

--- a/src/test/scala/org/zalando/jsonapi/json/JsonapiSupportSpec.scala
+++ b/src/test/scala/org/zalando/jsonapi/json/JsonapiSupportSpec.scala
@@ -47,5 +47,10 @@ trait JsonapiSupportSpec extends WordSpec with TypeCheckedTripleEquals with Eith
       val httpEntity = HttpEntity(`application/vnd.api+json`, """{"jsonapi":{"foo":"bar"}}""")
       assert(httpEntity.as[Foo] === Right(foo))
     }
+
+    "unmarshalling a malformed Json with the correct content type throw a malformedContent" in new Context {
+      val httpEntity = HttpEntity(`application/vnd.api+json`, """{{{{"jsonapi":{"foo":"bar"}}""")
+      assert(httpEntity.as[RootObject].left.value.isInstanceOf[MalformedContent])
+    }
   }
 }

--- a/src/test/scala/org/zalando/jsonapi/json/JsonapiSupportSpec.scala
+++ b/src/test/scala/org/zalando/jsonapi/json/JsonapiSupportSpec.scala
@@ -2,11 +2,13 @@ package org.zalando.jsonapi.json
 
 import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.{ EitherValues, WordSpec }
-import org.zalando.jsonapi.JsonapiRootObjectWriter
+import org.zalando.jsonapi.{JsonapiRootObjectReader, JsonapiRootObjectWriter}
 import org.zalando.jsonapi.json.sprayhttpx.SprayJsonapiSupport
 import org.zalando.jsonapi.model.{ JsonApiObject, JsonApiProperty, RootObject }
+import spray.http.HttpEntity
 import spray.httpx.marshalling._
 import spray.httpx.unmarshalling._
+import spray.http.MediaTypes.`application/vnd.api+json`
 
 trait JsonapiSupportSpec extends WordSpec with TypeCheckedTripleEquals with EitherValues with SprayJsonapiSupport {
   def jsonapiSupportClassName: String
@@ -33,18 +35,17 @@ trait JsonapiSupportSpec extends WordSpec with TypeCheckedTripleEquals with Eith
         """HttpEntity(application/vnd.api+json; charset=UTF-8,{"jsonapi":{"foo":"bar"}})""")
     }
 
-    // TODO Fix Play framework unmarshalling problem (issue #25 on github)
-    //    "allow unmarshalling a Json to a root object with the correct content type" in new Context {
-    //      val httpEntity = HttpEntity(`application/vnd.api+json`, """{"jsonapi":{"foo":"bar"}}""")
-    //      assert(httpEntity.as[RootObject] === Right(rootObject))
-    //    }
-    //
-    //    "allow unmarshalling Jsonapi root object to a value type" in new Context {
-    //      implicit val fooReader = new JsonapiRootObjectReader[Foo] {
-    //        override def fromJsonapi(ro: RootObject) = foo
-    //      }
-    //      val httpEntity = HttpEntity(`application/vnd.api+json`, """{"jsonapi":{"foo":"bar"}}""")
-    //      assert(httpEntity.as[Foo] === Right(foo))
-    //    }
+    "allow unmarshalling a Json to a root object with the correct content type" in new Context {
+      val httpEntity = HttpEntity(`application/vnd.api+json`, """{"jsonapi":{"foo":"bar"}}""")
+      assert(httpEntity.as[RootObject] === Right(rootObject))
+    }
+
+    "allow unmarshalling Jsonapi root object to a value type" in new Context {
+      implicit val fooReader = new JsonapiRootObjectReader[Foo] {
+        override def fromJsonapi(ro: RootObject) = foo
+      }
+      val httpEntity = HttpEntity(`application/vnd.api+json`, """{"jsonapi":{"foo":"bar"}}""")
+      assert(httpEntity.as[Foo] === Right(foo))
+    }
   }
 }


### PR DESCRIPTION
hi,

I resend my PR, see https://github.com/zalando/scala-jsonapi/pull/31

sorry for my english,
I think we need to use our own PlayJsonSupport marshaller because the default one provided by spray only support application/json ContentType

see: http://stackoverflow.com/questions/21362198/spray-io-mapping-request-from-text-json-to-application-json

sincerly,

Jeremie